### PR TITLE
Customize website for Manu Portuguez

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Particles Playground
+# Manu Portuguez Website
 
-A WebGL project driven by particles, built with Three.js and GSAP. The particles are constructed using custom shaders and utilize image textures as the base for coloring and rendering their appearance.
+This colorful WebGL playground is powered by Three.js and GSAP. Particles are constructed using custom shaders and textured images to create vibrant animations.
 
 ![Demo 1](https://github.com/user-attachments/assets/8adcc20f-205a-43e4-bd06-79a88d9db6d0)
 ![Demo 2](https://github.com/user-attachments/assets/20772a8e-5572-452d-a39e-481976484d97)
@@ -9,7 +9,7 @@ Custom shaders handle particle behavior, transforming images into interactive di
 
 This project utilizes GLSL 2D simplex noise within the shaders, originally developed by [Ian McEwan](https://github.com/ashima/webgl-noise/blob/master/src/noise2D.glsl). This project is inspired by [Bruno Imbrizi's Interactive Particles](https://github.com/brunoimbrizi/interactive-particles).
 
-For a more in-depth demo - check out my full Live Online example @ https://isladjan.com/work/3/quotes/
+For a more in-depth demo - check out my full Live Online example @ https://manuportuguez.com/
 
 <br />
 
@@ -94,10 +94,10 @@ Images used in this project were sourced from [Flickr](https://www.flickr.com/).
 
 # Full Live Demo + additional info
 
-[Full Live Demo](https://isladjan.com/work/3/)
+[Full Live Demo](https://manuportuguez.com/)
 
 
 
 # Author
 
-Sladjan Ilic - [isladjan.com](https://isladjan.com/)
+Manu Portuguez - [manuportuguez.com](https://manuportuguez.com/)

--- a/examples/style.scss
+++ b/examples/style.scss
@@ -54,12 +54,13 @@ li {
 /* Root Styles */
 :root {
   --font1: 'departure-mono', system-ui, 'Courier New', 'Courier', monospace;
+  --bg-gradient: linear-gradient(135deg, #ff7e5f 0%, #feb47b 100%);
   font-family: var(--font1);
   line-height: 1.5;
   font-weight: 400;
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  background: var(--bg-gradient);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -69,7 +70,7 @@ li {
 body {
   margin: 0;
   min-height: 100vh;
-  background-color: #242424;
+  background: var(--bg-gradient);
   display: grid;
   grid-template-columns: repeat(1fr, 2);
   grid-template-areas: "effect, links";

--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
-  <meta name="description" content="WebGL project driven by particles" />
-  <meta name="author" content="isladjan - ilic sladjan" />
-  <title>isladjan | Particles Playground</title>
+  <meta name="description" content="Manu Portuguez's colorful WebGL playground" />
+  <meta name="author" content="Manu Portuguez" />
+  <title>Manu Portuguez | Particles Playground</title>
   <style>
     body {
-      background-color: #242424;
+      background: linear-gradient(135deg, #ff7e5f 0%, #feb47b 100%);
     }
 
     .loading-msg {
@@ -18,7 +18,7 @@
         inset: 0;
         width: 100svw;
         height: 100svh;
-        background-color: #242424;
+        background: linear-gradient(135deg, #ff7e5f 0%, #feb47b 100%);
         display: flex;
         justify-content: center;
         align-items: center;
@@ -71,17 +71,17 @@
   <!-- links to the author's GitHub repository and website -->
   <div class="link-constainer">
 
-    <div class="top">
-      <h1>
-        <svg width="30" height="30" fill="none"><path fill="#fff" d="M12.5 16.25h-10v1.25H1.25v10H2.5v1.25h10V27.5h1.25v-10H12.5v-1.25Zm-1.25 10h-7.5v-7.5h7.5v7.5ZM12.5 2.5V1.25h-10V2.5H1.25v10H2.5v1.25h10V12.5h1.25v-10H12.5Zm-8.75 8.75v-7.5h7.5v7.5h-7.5ZM27.5 16.25h-10v1.25h-1.25v10h1.25v1.25h10V27.5h1.25v-10H27.5v-1.25Zm-1.25 10h-7.5v-7.5h7.5v7.5ZM27.5 2.5V1.25h-10V2.5h-1.25v10h1.25v1.25h10V12.5h1.25v-10H27.5Zm-1.25 8.75h-7.5v-7.5h7.5v7.5Z"/></svg>
-        <span>Particles Playground</span>
-      </h1>
+      <div class="top">
+        <h1>
+          <svg width="30" height="30" fill="none"><path fill="#fff" d="M12.5 16.25h-10v1.25H1.25v10H2.5v1.25h10V27.5h1.25v-10H12.5v-1.25Zm-1.25 10h-7.5v-7.5h7.5v7.5ZM12.5 2.5V1.25h-10V2.5H1.25v10H2.5v1.25h10V12.5h1.25v-10H12.5Zm-8.75 8.75v-7.5h7.5v7.5h-7.5ZM27.5 16.25h-10v1.25h-1.25v10h1.25v1.25h10V27.5h1.25v-10H27.5v-1.25Zm-1.25 10h-7.5v-7.5h7.5v7.5ZM27.5 2.5V1.25h-10V2.5h-1.25v10h1.25v1.25h10V12.5h1.25v-10H27.5Zm-1.25 8.75h-7.5v-7.5h7.5v7.5Z"/></svg>
+          <span>Manu Portuguez</span>
+        </h1>
 
-      <a class="original-link" href="https://isladjan.com/work/3/quotes" target="_blank" rel="noopener"><span>Full Live Demo</span></a>
+        <a class="original-link" href="https://manuportuguez.com" target="_blank" rel="noopener"><span>Full Live Demo</span></a>
     </div>
 
     <div class="bottom">
-      <a class="gitHub" href="https://github.com/isladjan/quotes" target="_blank" rel="noopener">
+        <a class="gitHub" href="https://github.com/manuportuguez" target="_blank" rel="noopener">
         <svg width="24" height="24" viewBox="0 0 24 24">
           <path fill="currentColor"
             d="M12 2A10 10 0 0 0 2 12c0 4.42 2.87 8.17 6.84 9.5c.5.08.66-.23.66-.5v-1.69c-2.77.6-3.36-1.34-3.36-1.34c-.46-1.16-1.11-1.47-1.11-1.47c-.91-.62.07-.6.07-.6c1 .07 1.53 1.03 1.53 1.03c.87 1.52 2.34 1.07 2.91.83c.09-.65.35-1.09.63-1.34c-2.22-.25-4.55-1.11-4.55-4.92c0-1.11.38-2 1.03-2.71c-.1-.25-.45-1.29.1-2.64c0 0 .84-.27 2.75 1.02c.79-.22 1.65-.33 2.5-.33s1.71.11 2.5.33c1.91-1.29 2.75-1.02 2.75-1.02c.55 1.35.2 2.39.1 2.64c.65.71 1.03 1.6 1.03 2.71c0 3.82-2.34 4.66-4.57 4.91c.36.31.69.92.69 1.85V21c0 .27.16.59.67.5C19.14 20.16 22 16.42 22 12A10 10 0 0 0 12 2" />
@@ -89,7 +89,7 @@
         <span>GitHub</span>
       </a>
 
-      <a class="copyright" href="https://isladjan.com/" target="_blank" rel="noopener"><span class="sign">©</span>2025 isladjan</a>
+        <a class="copyright" href="https://manuportuguez.com/" target="_blank" rel="noopener"><span class="sign">©</span>2025 Manu Portuguez</a>
     </div>
 
   </div>


### PR DESCRIPTION
## Summary
- update README to reference Manu Portuguez
- add bright gradient theme
- rename headings and author info in HTML

## Testing
- `npm install --no-optional`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_685224da1968833290a828052fd8c6f7